### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,5 +1,8 @@
 name: Build and Test
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/jonesrussell/godo/security/code-scanning/9](https://github.com/jonesrussell/godo/security/code-scanning/9)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the workflow's operations, it appears that the workflow primarily needs read access to the repository contents and write access to pull requests (if applicable). We will set `contents: read` as a baseline and add any additional permissions explicitly if required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
