### PR TITLE
chore(spec-kitty): enable Spec Kitty and add project charter

### DIFF
--- a/.github/workflows/spec-kitty.yml
+++ b/.github/workflows/spec-kitty.yml
@@ -1,0 +1,49 @@
+name: Spec Kitty governance
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.kittify/**'
+      - '.github/workflows/spec-kitty.yml'
+      - 'scripts/check-charter.sh'
+      - 'Taskfile.yml'
+      - 'docs/SPEC-KITTY.md'
+  pull_request:
+    branches: [main]
+    paths:
+      - '.kittify/**'
+      - '.github/workflows/spec-kitty.yml'
+      - 'scripts/check-charter.sh'
+      - 'Taskfile.yml'
+      - 'docs/SPEC-KITTY.md'
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Spec Kitty CLI
+        run: |
+          pip install --upgrade pip
+          pip install "spec-kitty-cli==3.1.7"
+
+      - name: Check charter file presence
+        run: ./scripts/check-charter.sh
+
+      - name: spec-kitty verify-setup
+        run: spec-kitty verify-setup
+
+      - name: Charter status and drift (read-only)
+        run: |
+          spec-kitty charter status --json | tee charter-status.json
+          test "$(jq -r '.status' charter-status.json)" = "synced"
+          jq -e '.current_hash == .stored_hash' charter-status.json > /dev/null

--- a/.kittify/charter/charter.md
+++ b/.kittify/charter/charter.md
@@ -1,0 +1,117 @@
+# Project Charter — Godo
+
+Human-edited governance for **Godo**: a local-first desktop companion that will serve as the **system-level interface** to one or more AI harnesses. The historical “quick notes / todos” surface is being **re-centered on durable, queryable state** and an **audit trail**, not on ephemeral UI-only lists.
+
+**Harness work for now:** Treat any remote AI harness as **pluggable behind a small interface**. Use **in-memory fakes, `httptest` servers, and golden/fixture payloads** in tests and local dev until a real integration is explicitly chartered. Production coupling to a specific host (for example Claudriel) is **out of scope** until you add it back in a mission and bump this charter.
+
+Last amended: 2026-05-07
+
+---
+
+## Identity and north star
+
+1. **Local authority:** The desktop client owns capture UX (hotkeys, windows), local policy defaults, and persisted artifacts the user should retain without network access.
+2. **Harness boundary:** A harness (local or remote) provides model/session orchestration **only through a documented client boundary** in this codebase—implemented with **swappable adapters**, not ad hoc HTTP scattered across UI.
+3. **Truth in SQLite:** User-visible state, conversation transcripts (as the product evolves), and **audit metadata** live in **SQLite** as the **canonical source of truth** for the local agent. Other caches or in-memory views are projections, not competing primaries.
+4. **Spec-driven change:** Material pivots (storage schema, harness boundary, trust boundaries) go through Spec Kitty **specify → plan → tasks** and are reflected here when governance changes.
+
+---
+
+## Testing standards
+
+- Target **80%+ test coverage** on domain and application packages; infrastructure may be lower but must be justified in review.
+- Use **`go test ./...`** with **`-tags=wireinject`** wherever Wire-generated code or DI graphs participate in tests (see project `CLAUDE.md`).
+- Prefer table-driven tests for branching logic; use `t.TempDir()` for filesystem-backed tests.
+- **Harness-facing code** is tested against **fixtures and test doubles** by default; contract-style tests may spin a **local `httptest.Server`** instead of calling real external services in CI or default `go test`.
+
+---
+
+## Quality and linting gates
+
+- **`task fmt`** then **`task lint`** (or `task check` for a fast gate) before merge unless a mission documents an exception.
+- Primary linter: **golangci-lint** (project toolchain). Fix or suppress with narrow scope and comment.
+- **1 approval** required before merging to `main`.
+
+---
+
+## Commits and change hygiene
+
+- **Conventional commits** for changelog and release hygiene unless a one-off hotfix branch is explicitly agreed.
+- Cross-cutting changes (storage schema, public API surface, harness adapter interfaces) should be **one logical commit or a small series** with a clear message scope.
+
+---
+
+## Performance targets
+
+- Routine **local** operations (open window, list/query local store, append audit row) should complete in **under 2 seconds** on a typical dev machine, excluding optional network calls to a harness.
+- Any future **live harness I/O** must be **off the UI thread** (async, cancellation, bounded timeouts); until wired, this is satisfied by not blocking Fyne on network calls in new code paths.
+
+---
+
+## Branch strategy
+
+1. Branch `main` is the integration branch; default to short-lived feature branches.
+2. When Spec Kitty lanes are active, follow lane merge rules from mission docs; do not merge drifted charter bundles.
+3. External harness wire-ups: when a real remote is introduced, document request and event assumptions in a mission spec (and extend this charter if governance changes); until then, fixtures only in tree.
+
+---
+
+## Governance activation
+
+```yaml
+mission: software-dev
+selected_paradigms: []
+selected_directives: []
+available_tools: [git, spec-kitty]
+template_set: software-dev-default
+```
+
+---
+
+## Data store: SQLite as source of truth
+
+| Concern | Decision |
+| --- | --- |
+| Primary persistence | **SQLite** (single canonical DB path per install; migrations versioned in-repo). |
+| Todos / notes | Legacy “todo list” semantics migrate toward **first-class entities** (e.g. messages, threads, tasks) stored in normalized tables—not as the only copy in widget state. |
+| Audit | Maintain an **append-only audit log** (or append-only event table) for operations that matter for **trust, replay, or future cross-system reconciliation**. Redaction/deletion is a **policy layer**, not silent row loss without trace. |
+| API / other backends | Optional HTTP storage remains **secondary** unless explicitly configured; if enabled, **sync rules and conflict policy** must be specified in a mission spec, not ad hoc. |
+
+---
+
+## Deferred: live harness integration
+
+A future mission may attach a concrete remote (for example **Claudriel**). Until then:
+
+- **No required dependency** on any specific harness URL or auth flow in application code paths used for default builds.
+- **Fixtures and fakes** are the expected way to exercise parsing, persistence, and UI flows that will eventually talk to a real API.
+- When integration lands, add a short **wire + trust** subsection here (or link to an OpenAPI artifact) and add **contract tests** that still run fully offline using recorded responses where appropriate.
+
+---
+
+## Project directives
+
+1. Single primary store: do not introduce a second primary mutable store for the same logical entities without a chartered migration and dual-write/dual-read plan.
+2. Audit accountability: mutations that affect user trust or future harness reconciliation must be observable (append-only log or equivalent immutable history).
+3. Harness adapter and fixtures: outbound “harness” behavior lives behind an explicit interface; tests use fakes or `httptest`—not live third-party services—unless a mission opts into a gated integration suite.
+4. Architecture respect: preserve domain, application, and infrastructure separation unless a mission explicitly redesigns boundaries.
+5. Workflow: non-trivial work uses Spec Kitty artifacts so implementation stays reviewable and reversible.
+
+---
+
+## Amendment process
+
+Amendments ship via PR with **at least one reviewer** and an explicit note if **governance.yaml** / **directives.yaml** outputs change behavior for agents.
+
+## Exception policy
+
+Time-bounded exceptions are allowed for experiments; document **rationale**, **expiry**, and **follow-up issue** in the PR or mission dossier.
+
+---
+
+## Reference index
+
+| Reference ID | Kind | Summary | Local Doc |
+| --- | --- | --- |
+| `USER:PROJECT_PROFILE` | user_profile | Interview-derived defaults when present. | `_LIBRARY/user-project-profile.md` |
+| `TEMPLATE_SET:software-dev-default` | template_set | Default software mission doctrine bundle. | `_LIBRARY/template-set-software-dev-default.md` |

--- a/.kittify/charter/directives.yaml
+++ b/.kittify/charter/directives.yaml
@@ -1,0 +1,24 @@
+# Auto-generated from charter.md — do not edit directly.
+# Run 'spec-kitty charter sync' to regenerate.
+
+directives:
+- id: DIR-001
+  title: 'Single primary store: do not introduce a second pr'
+  description: 'Single primary store: do not introduce a second primary mutable store for the same logical entities without a chartered migration and dual-write/dual-read plan.'
+  severity: warn
+- id: DIR-002
+  title: 'Audit accountability: mutations that affect user t'
+  description: 'Audit accountability: mutations that affect user trust or future harness reconciliation must be observable (append-only log or equivalent immutable history).'
+  severity: warn
+- id: DIR-003
+  title: 'Harness adapter and fixtures: outbound “harness” b'
+  description: 'Harness adapter and fixtures: outbound “harness” behavior lives behind an explicit interface; tests use fakes or `httptest`—not live third-party services—unless a mission opts into a gated integration suite.'
+  severity: warn
+- id: DIR-004
+  title: 'Architecture respect: preserve domain, application'
+  description: 'Architecture respect: preserve domain, application, and infrastructure separation unless a mission explicitly redesigns boundaries.'
+  severity: warn
+- id: DIR-005
+  title: 'Workflow: non-trivial work uses Spec Kitty artifac'
+  description: 'Workflow: non-trivial work uses Spec Kitty artifacts so implementation stays reviewable and reversible.'
+  severity: warn

--- a/.kittify/charter/governance.yaml
+++ b/.kittify/charter/governance.yaml
@@ -1,0 +1,32 @@
+# Auto-generated from charter.md — do not edit directly.
+# Run 'spec-kitty charter sync' to regenerate.
+
+testing:
+  min_coverage: 80
+  tdd_required: false
+  framework: ''
+  type_checking: ''
+quality:
+  linting: ''
+  pr_approvals: 1
+  pre_commit_hooks: false
+commits:
+  convention: conventional
+performance:
+  cli_timeout_seconds: 2.0
+  dashboard_max_wps: 100
+branch_strategy:
+  main_branch: main
+  dev_branch:
+  rules:
+  - Branch `main` is the integration branch; default to short-lived feature branches.
+  - When Spec Kitty lanes are active, follow lane merge rules from mission docs; do not merge drifted charter bundles.
+  - 'External harness wire-ups: when a real remote is introduced, document request and event assumptions in a mission spec (and extend this charter if governance changes); until then, fixtures only in tree.'
+doctrine:
+  selected_paradigms: []
+  selected_directives: []
+  available_tools:
+  - git
+  - spec-kitty
+  template_set: software-dev-default
+enforcement: {}

--- a/.kittify/charter/metadata.yaml
+++ b/.kittify/charter/metadata.yaml
@@ -1,0 +1,12 @@
+# Auto-generated from charter.md — do not edit directly.
+# Run 'spec-kitty charter sync' to regenerate.
+
+schema_version: 1.0.0
+extracted_at: '2026-05-07T01:11:13.966704+00:00'
+charter_hash: sha256:6fde7648b418d05c496f2892791ce3e30e42f29dc8658c906a6d68134d71224c
+source_path: .kittify/charter/charter.md
+extraction_mode: hybrid
+sections_parsed:
+  structured: 9
+  ai_assisted: 5
+  skipped: 0

--- a/.kittify/charter/references.yaml
+++ b/.kittify/charter/references.yaml
@@ -1,0 +1,18 @@
+schema_version: 1.0.0
+generated_at: '2026-05-06T23:28:27Z'
+mission: software-dev
+template_set: software-dev-default
+references:
+- id: USER:PROJECT_PROFILE
+  kind: user_profile
+  title: User Project Profile
+  summary: Project-specific interview answers captured for charter compilation.
+  source_path: .kittify/charter/interview/answers.yaml
+  local_path: _LIBRARY/user-project-profile.md
+- id: TEMPLATE_SET:software-dev-default
+  kind: template_set
+  title: software-dev-default
+  summary: Build high-quality software with structured workflows and test-driven
+    development
+  source_path: ""
+  local_path: _LIBRARY/template-set-software-dev-default.md

--- a/.kittify/config.yaml
+++ b/.kittify/config.yaml
@@ -1,0 +1,14 @@
+charter_path: .kittify/charter/charter.md
+default_template_set: software-dev-default
+verify_setup_cmds:
+  - spec-kitty verify-setup
+
+vcs:
+  type: git
+
+agents:
+  available:
+    - cursor
+    - claude
+    - codex
+  auto_commit: true

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -267,3 +267,13 @@ tasks:
     cmds:
     - echo "Testing GUI in WSL2 environment"
     - go test -v ./internal/gui/...
+
+  spec:verify:
+    desc: Verify Spec Kitty installation and repo governance files
+    cmds:
+    - spec-kitty verify-setup
+
+  spec:sync:
+    desc: Sync charter.md to extracted governance YAML (run after charter edits)
+    cmds:
+    - spec-kitty charter sync

--- a/docs/SPEC-KITTY.md
+++ b/docs/SPEC-KITTY.md
@@ -1,0 +1,24 @@
+# Spec Kitty governance
+
+Spec Kitty provides **spec-driven governance** for this repository: a human-edited charter (`.kittify/charter/charter.md`) is the source of truth, and extracted YAML under `.kittify/charter/` keeps machine-readable policy aligned with that charter. CI verifies the install and detects charter drift so merges do not silently desync governance from the document maintainers edit.
+
+## Local commands
+
+From the repository root (with [Task](https://taskfile.dev/) installed):
+
+- **`task spec:verify`** — runs `spec-kitty verify-setup` (see `.kittify/config.yaml` `verify_setup_cmds`).
+- **`task spec:sync`** — runs `spec-kitty charter sync` after you change `charter.md`; commit the updated extracted files when the charter meaningfully changes.
+
+Install the CLI if missing (recommended):
+
+```bash
+pip install spec-kitty-cli
+```
+
+## Policy
+
+**Do not wire external harnesses into `main` without a mission and charter amendment.** Remote integrations, live third-party services, and new trust boundaries belong in Spec Kitty mission artifacts and must be reflected in the charter before production code depends on them.
+
+## CI
+
+The workflow `.github/workflows/spec-kitty.yml` runs on pushes and pull requests to `main`. It installs `spec-kitty-cli` via pip, runs `scripts/check-charter.sh`, `spec-kitty verify-setup`, and a read-only drift check using `spec-kitty charter status --json` (`status` must be `synced`, and `current_hash` must equal `stored_hash`).

--- a/scripts/check-charter.sh
+++ b/scripts/check-charter.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Fail if the Spec Kitty charter is missing or empty (CI / local guard).
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHARTER="${ROOT}/.kittify/charter/charter.md"
+if [[ ! -f "${CHARTER}" ]]; then
+  echo "check-charter: missing ${CHARTER}" >&2
+  exit 1
+fi
+if [[ ! -s "${CHARTER}" ]]; then
+  echo "check-charter: empty ${CHARTER}" >&2
+  exit 1
+fi
+echo "check-charter: OK (${CHARTER})"


### PR DESCRIPTION
## Summary
- Add the finalized **Godo project charter** at `.kittify/charter/charter.md` (including the governance activation YAML block).
- Add **Spec Kitty config** (`.kittify/config.yaml`), **Task** targets `spec:verify` / `spec:sync`, and `scripts/check-charter.sh`.
- Add **CI workflow** `.github/workflows/spec-kitty.yml` (pip install `spec-kitty-cli`, verify-setup, read-only charter drift via `charter status --json`) plus `docs/SPEC-KITTY.md`.

## Acceptance criteria
- [ ] `.kittify/charter/charter.md` exists and matches the agreed charter wording (UTF-8, governance block preserved).
- [ ] `spec-kitty verify-setup` succeeds in CI for this PR (see workflow logs).
- [ ] `task spec:verify` works locally per `docs/SPEC-KITTY.md` (requires `spec-kitty-cli` on PATH).

## Install note
CI uses the documented method from Spec Kitty setup guidance: `pip install "spec-kitty-cli==3.1.7"`.

## Commits
1. `chore(spec-kitty): add charter file`
2. `chore(spec-kitty): add config, Taskfile targets, and check script`
3. `chore(spec-kitty): add CI workflow and docs`


Made with [Cursor](https://cursor.com)