### PR TITLE
wp03(runtime): root context + signal handling

### DIFF
--- a/docs/runtime/lifecycle-baseline.md
+++ b/docs/runtime/lifecycle-baseline.md
@@ -1,0 +1,25 @@
+# Runtime Lifecycle Baseline
+
+This document tracks lifecycle responsibilities while the runtime layer is being
+introduced incrementally.
+
+## Existing Signal Pattern (Current `main.go`)
+- `main.go` currently creates a dedicated `sigChan` using `signal.Notify`.
+- A signal goroutine waits for `SIGINT`/`SIGTERM`.
+- On signal, that goroutine triggers app termination flow and a force-kill timer.
+
+## WP03: Root Context + Signal Handling Integration
+WP03 introduces `internal/runtime` signal/context primitives that replace the
+ad-hoc `sigChan` ownership pattern with context-first wiring:
+
+- `NewRootContext()` creates a root context backed by `signal.NotifyContext`
+  and listens for `SIGINT` + `SIGTERM`.
+- `WithSignals(parent, ...)` provides a testable helper for signal-bound
+  context creation.
+- Callers now receive `(context.Context, context.CancelFunc)` and can compose
+  lifecycle cancellation through context instead of directly managing signal
+  channels.
+
+This WP does **not** move cleanup orchestration or `main.go` wiring yet; it
+only establishes the runtime-owned signal/context boundary used by later WPs.
+

--- a/internal/runtime/signals.go
+++ b/internal/runtime/signals.go
@@ -1,0 +1,28 @@
+package runtime
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+// NewRootContext creates the root runtime context bound to process interrupt
+// signals. The returned cancel function must always be called by the caller to
+// stop signal delivery and release internal resources.
+func NewRootContext() (context.Context, context.CancelFunc) {
+	return WithSignals(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+}
+
+// WithSignals creates a context cancelled by either parent cancellation or any
+// of the provided OS signals. This WP03 helper only wires signal/context
+// behavior; shutdown orchestration is intentionally deferred.
+func WithSignals(parent context.Context, signals ...os.Signal) (context.Context, context.CancelFunc) {
+	if parent == nil {
+		parent = context.Background()
+	}
+	if len(signals) == 0 {
+		signals = []os.Signal{syscall.SIGINT, syscall.SIGTERM}
+	}
+	return signal.NotifyContext(parent, signals...)
+}

--- a/internal/runtime/signals_test.go
+++ b/internal/runtime/signals_test.go
@@ -1,0 +1,63 @@
+package runtime
+
+import (
+	"context"
+	"os"
+	"runtime"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestWithSignals_CancelsOnSignal(t *testing.T) {
+	ctx, cancel := WithSignals(context.Background(), syscall.SIGUSR1)
+	t.Cleanup(cancel)
+
+	proc, err := os.FindProcess(os.Getpid())
+	if err != nil {
+		t.Fatalf("find process: %v", err)
+	}
+
+	if err := proc.Signal(syscall.SIGUSR1); err != nil {
+		t.Fatalf("send signal: %v", err)
+	}
+
+	select {
+	case <-ctx.Done():
+		// Expected.
+	case <-time.After(2 * time.Second):
+		t.Fatal("context was not canceled after signal")
+	}
+}
+
+func TestWithSignals_CancelFuncWorksWithoutSignal(t *testing.T) {
+	ctx, cancel := WithSignals(context.Background(), syscall.SIGUSR1)
+	cancel()
+
+	select {
+	case <-ctx.Done():
+		// Expected.
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("context was not canceled by cancel func")
+	}
+}
+
+func TestWithSignals_NoGoroutineLeakSmoke(t *testing.T) {
+	before := runtime.NumGoroutine()
+
+	for i := 0; i < 25; i++ {
+		_, cancel := WithSignals(context.Background(), syscall.SIGUSR1)
+		cancel()
+	}
+
+	// Give the runtime time to run defers/cleanup from signal.NotifyContext.
+	time.Sleep(100 * time.Millisecond)
+	runtime.GC()
+	time.Sleep(100 * time.Millisecond)
+
+	after := runtime.NumGoroutine()
+	if after > before+5 {
+		t.Fatalf("possible goroutine leak: before=%d after=%d", before, after)
+	}
+}
+


### PR DESCRIPTION
## Summary
- implement root runtime context helpers in `internal/runtime/signals.go` using `signal.NotifyContext`
- add `NewRootContext()` for `SIGINT` + `SIGTERM` and `WithSignals(...)` for reusable/testable signal-context wiring
- add runtime unit tests validating signal cancellation, manual cancel behavior, and goroutine-leak smoke checks
- update `docs/runtime/lifecycle-baseline.md` with a new "WP03: Root Context + Signal Handling Integration" section describing replacement of the old `sigChan` pattern

Related mission: [#90](https://github.com/jonesrussell/godo/pull/90)

## Acceptance criteria
- [x] runtime context creation implemented
- [x] signal handling implemented
- [x] tests included
- [x] no changes to `main.go` yet

Made with [Cursor](https://cursor.com)